### PR TITLE
Add params support

### DIFF
--- a/spring-cloud-deployer-yarn-tasklauncherappmaster/src/main/java/org/springframework/cloud/deployer/spi/yarn/tasklauncher/TaskAppmaster.java
+++ b/spring-cloud-deployer-yarn-tasklauncherappmaster/src/main/java/org/springframework/cloud/deployer/spi/yarn/tasklauncher/TaskAppmaster.java
@@ -84,6 +84,11 @@ public class TaskAppmaster extends StaticEventingAppmaster {
 				list.add(Math.max(list.size() - 2, 0), "--" + entry.getKey() + "='" + entry.getValue() + "'");
 			}
 		}
+		if (taskAppmasterProperties.getCommandlineArguments() != null) {
+			for (String commandlineArgument : taskAppmasterProperties.getCommandlineArguments()) {
+				list.add(Math.max(list.size() - 2, 0), "'" + commandlineArgument + "'");
+			}
+		}
 		return list;
 	}
 

--- a/spring-cloud-deployer-yarn-tasklauncherappmaster/src/main/java/org/springframework/cloud/deployer/spi/yarn/tasklauncher/TaskAppmasterProperties.java
+++ b/spring-cloud-deployer-yarn-tasklauncherappmaster/src/main/java/org/springframework/cloud/deployer/spi/yarn/tasklauncher/TaskAppmasterProperties.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.deployer.spi.yarn.tasklauncher;
 
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -30,6 +31,7 @@ public class TaskAppmasterProperties {
 
 	private String artifact;
 	private Map<String, String> parameters;
+	private List<String> commandlineArguments;
 
 	public String getArtifact() {
 		return artifact;
@@ -45,5 +47,13 @@ public class TaskAppmasterProperties {
 
 	public void setParameters(Map<String, String> parameters) {
 		this.parameters = parameters;
+	}
+
+	public List<String> getCommandlineArguments() {
+		return commandlineArguments;
+	}
+
+	public void setCommandlineArguments(List<String> commandlineArguments) {
+		this.commandlineArguments = commandlineArguments;
 	}
 }

--- a/spring-cloud-deployer-yarn/src/main/java/org/springframework/cloud/deployer/spi/yarn/YarnTaskLauncher.java
+++ b/spring-cloud-deployer-yarn/src/main/java/org/springframework/cloud/deployer/spi/yarn/YarnTaskLauncher.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.deployer.spi.yarn;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
@@ -81,6 +82,7 @@ public class YarnTaskLauncher implements TaskLauncher {
 		final String name = definition.getName();
 		Map<String, String> definitionParameters = definition.getProperties();
 		Map<String, String> environmentProperties = request.getEnvironmentProperties();
+		List<String> commandlineArguments = request.getCommandlineArguments();
 		String appName = "scdtask:" + name;
 
 		// contextRunArgs are passed to boot app ran to control yarn apps
@@ -91,6 +93,13 @@ public class YarnTaskLauncher implements TaskLauncher {
 		contextRunArgs.add("--spring.yarn.appName=" + appName);
 		for (Entry<String, String> entry : definitionParameters.entrySet()) {
 			contextRunArgs.add("--spring.yarn.client.launchcontext.arguments.--spring.cloud.deployer.yarn.appmaster.parameters." + entry.getKey() + ".='" + entry.getValue() + "'");
+		}
+
+		int index = 0;
+		for (String commandlineArgument : commandlineArguments) {
+			contextRunArgs.add("--spring.yarn.client.launchcontext.argumentsList[" + index
+					+ "]='--spring.cloud.deployer.yarn.appmaster.commandlineArguments[" + index + "]=" + commandlineArgument + "'");
+			index++;
 		}
 
 		String artifactPath = isHdfsResource(resource) ? getHdfsArtifactPath(resource) : "/dataflow/artifacts/cache/";


### PR DESCRIPTION
- Add commandline support for tasks.
- Fixes #9 

```
dataflow:>task create --name footask1 --definition "timestamp --format=yyyyMM"
dataflow:>task create --name footask2 --definition "timestamp"

dataflow:>task launch --name footask1
dataflow:>task launch --name footask2 --params "--format=yyyyMM"
```
