### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/NOTICE
+++ b/NOTICE
@@ -6,7 +6,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+  https://www.apache.org/licenses/LICENSE-2.0
  
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-yarn-appdeployerappmaster/src/main/java/org/springframework/cloud/deployer/spi/yarn/appdeployer/StreamAppmaster.java
+++ b/spring-cloud-deployer-yarn-appdeployerappmaster/src/main/java/org/springframework/cloud/deployer/spi/yarn/appdeployer/StreamAppmaster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-yarn-appdeployerappmaster/src/main/java/org/springframework/cloud/deployer/spi/yarn/appdeployer/StreamAppmasterApplication.java
+++ b/spring-cloud-deployer-yarn-appdeployerappmaster/src/main/java/org/springframework/cloud/deployer/spi/yarn/appdeployer/StreamAppmasterApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-yarn-appdeployerappmaster/src/main/java/org/springframework/cloud/deployer/spi/yarn/appdeployer/StreamAppmasterProperties.java
+++ b/spring-cloud-deployer-yarn-appdeployerappmaster/src/main/java/org/springframework/cloud/deployer/spi/yarn/appdeployer/StreamAppmasterProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-yarn-autoconfig/src/main/java/org/springframework/cloud/deployer/spi/yarn/autoconfigure/YarnDeployerAutoConfiguration.java
+++ b/spring-cloud-deployer-yarn-autoconfig/src/main/java/org/springframework/cloud/deployer/spi/yarn/autoconfigure/YarnDeployerAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-yarn-build-tests/src/test/java/org/springframework/cloud/dataflow/yarn/buildtests/AbstractCliBootYarnClusterTests.java
+++ b/spring-cloud-deployer-yarn-build-tests/src/test/java/org/springframework/cloud/dataflow/yarn/buildtests/AbstractCliBootYarnClusterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-yarn-build-tests/src/test/java/org/springframework/cloud/dataflow/yarn/buildtests/AppDeployerIT.java
+++ b/spring-cloud-deployer-yarn-build-tests/src/test/java/org/springframework/cloud/dataflow/yarn/buildtests/AppDeployerIT.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-yarn-build-tests/src/test/java/org/springframework/cloud/dataflow/yarn/buildtests/TaskLauncherIT.java
+++ b/spring-cloud-deployer-yarn-build-tests/src/test/java/org/springframework/cloud/dataflow/yarn/buildtests/TaskLauncherIT.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-yarn-tasklauncherappmaster/src/main/java/org/springframework/cloud/deployer/spi/yarn/tasklauncher/TaskAppmaster.java
+++ b/spring-cloud-deployer-yarn-tasklauncherappmaster/src/main/java/org/springframework/cloud/deployer/spi/yarn/tasklauncher/TaskAppmaster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-yarn-tasklauncherappmaster/src/main/java/org/springframework/cloud/deployer/spi/yarn/tasklauncher/TaskAppmasterApplication.java
+++ b/spring-cloud-deployer-yarn-tasklauncherappmaster/src/main/java/org/springframework/cloud/deployer/spi/yarn/tasklauncher/TaskAppmasterApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-yarn-tasklauncherappmaster/src/main/java/org/springframework/cloud/deployer/spi/yarn/tasklauncher/TaskAppmasterProperties.java
+++ b/spring-cloud-deployer-yarn-tasklauncherappmaster/src/main/java/org/springframework/cloud/deployer/spi/yarn/tasklauncher/TaskAppmasterProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-yarn/src/main/java/org/springframework/cloud/deployer/spi/yarn/AbstractDeployerStateMachine.java
+++ b/spring-cloud-deployer-yarn/src/main/java/org/springframework/cloud/deployer/spi/yarn/AbstractDeployerStateMachine.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-yarn/src/main/java/org/springframework/cloud/deployer/spi/yarn/AppDeployerStateMachine.java
+++ b/spring-cloud-deployer-yarn/src/main/java/org/springframework/cloud/deployer/spi/yarn/AppDeployerStateMachine.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-yarn/src/main/java/org/springframework/cloud/deployer/spi/yarn/DefaultYarnCloudAppService.java
+++ b/spring-cloud-deployer-yarn/src/main/java/org/springframework/cloud/deployer/spi/yarn/DefaultYarnCloudAppService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-yarn/src/main/java/org/springframework/cloud/deployer/spi/yarn/DeployerApplicationYarnClient.java
+++ b/spring-cloud-deployer-yarn/src/main/java/org/springframework/cloud/deployer/spi/yarn/DeployerApplicationYarnClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-yarn/src/main/java/org/springframework/cloud/deployer/spi/yarn/StreamClustersInfoReportData.java
+++ b/spring-cloud-deployer-yarn/src/main/java/org/springframework/cloud/deployer/spi/yarn/StreamClustersInfoReportData.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-yarn/src/main/java/org/springframework/cloud/deployer/spi/yarn/TaskLauncherStateMachine.java
+++ b/spring-cloud-deployer-yarn/src/main/java/org/springframework/cloud/deployer/spi/yarn/TaskLauncherStateMachine.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-yarn/src/main/java/org/springframework/cloud/deployer/spi/yarn/YarnAppDeployer.java
+++ b/spring-cloud-deployer-yarn/src/main/java/org/springframework/cloud/deployer/spi/yarn/YarnAppDeployer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-yarn/src/main/java/org/springframework/cloud/deployer/spi/yarn/YarnCloudAppService.java
+++ b/spring-cloud-deployer-yarn/src/main/java/org/springframework/cloud/deployer/spi/yarn/YarnCloudAppService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-yarn/src/main/java/org/springframework/cloud/deployer/spi/yarn/YarnCloudAppServiceApplication.java
+++ b/spring-cloud-deployer-yarn/src/main/java/org/springframework/cloud/deployer/spi/yarn/YarnCloudAppServiceApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-yarn/src/main/java/org/springframework/cloud/deployer/spi/yarn/YarnDeployerProperties.java
+++ b/spring-cloud-deployer-yarn/src/main/java/org/springframework/cloud/deployer/spi/yarn/YarnDeployerProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-yarn/src/main/java/org/springframework/cloud/deployer/spi/yarn/YarnTaskLauncher.java
+++ b/spring-cloud-deployer-yarn/src/main/java/org/springframework/cloud/deployer/spi/yarn/YarnTaskLauncher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-yarn/src/test/java/org/springframework/cloud/deployer/spi/yarn/AbstractStateMachineTests.java
+++ b/spring-cloud-deployer-yarn/src/test/java/org/springframework/cloud/deployer/spi/yarn/AbstractStateMachineTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-yarn/src/test/java/org/springframework/cloud/deployer/spi/yarn/AppDeployerStateMachineTests.java
+++ b/spring-cloud-deployer-yarn/src/test/java/org/springframework/cloud/deployer/spi/yarn/AppDeployerStateMachineTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-deployer-yarn/src/test/java/org/springframework/cloud/deployer/spi/yarn/TaskLauncherStateMachineTests.java
+++ b/spring-cloud-deployer-yarn/src/test/java/org/springframework/cloud/deployer/spi/yarn/TaskLauncherStateMachineTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 26 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).