### PR TITLE
URL Cleanup

### DIFF
--- a/spring-cloud-deployer-yarn/src/main/resources/appdeployer-model.di
+++ b/spring-cloud-deployer-yarn/src/main/resources/appdeployer-model.di
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"/>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="https://www.omg.org/XMI"/>

--- a/spring-cloud-deployer-yarn/src/main/resources/appdeployer-model.notation
+++ b/spring-cloud-deployer-yarn/src/main/resources/appdeployer-model.notation
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<notation:Diagram xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/viewpoints/policy/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_K8k3wRZ5EeaeH5SlvwGOyg" type="PapyrusUMLStateMachineDiagram" name="StateMachine Diagram" measurementUnit="Pixel">
+<notation:Diagram xmi:version="2.0" xmlns:xmi="https://www.omg.org/XMI" xmlns:ecore="https://www.eclipse.org/emf/2002/Ecore" xmlns:notation="https://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="https://www.eclipse.org/papyrus/infra/viewpoints/policy/style" xmlns:uml="https://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_K8k3wRZ5EeaeH5SlvwGOyg" type="PapyrusUMLStateMachineDiagram" name="StateMachine Diagram" measurementUnit="Pixel">
   <children xmi:type="notation:Shape" xmi:id="_K8k3whZ5EeaeH5SlvwGOyg" type="2000">
     <children xmi:type="notation:DecorationNode" xmi:id="_K8k3wxZ5EeaeH5SlvwGOyg" type="2001">
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K8k3xBZ5EeaeH5SlvwGOyg" width="954" height="23"/>

--- a/spring-cloud-deployer-yarn/src/main/resources/appdeployer-model.uml
+++ b/spring-cloud-deployer-yarn/src/main/resources/appdeployer-model.uml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<uml:Model xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_K8gmUBZ5EeaeH5SlvwGOyg" name="RootElement">
+<uml:Model xmi:version="20131001" xmlns:xmi="https://www.omg.org/spec/XMI/20131001" xmlns:uml="https://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_K8gmUBZ5EeaeH5SlvwGOyg" name="RootElement">
   <packagedElement xmi:type="uml:StateMachine" xmi:id="_K8jCkBZ5EeaeH5SlvwGOyg" name="StateMachine">
     <region xmi:type="uml:Region" xmi:id="_K8k3wBZ5EeaeH5SlvwGOyg" name="Region1">
       <transition xmi:type="uml:Transition" xmi:id="_XuVdkBZ6EeaeH5SlvwGOyg" source="_VWNIkBZ6EeaeH5SlvwGOyg" target="_R-ur4BZ5EeaeH5SlvwGOyg"/>

--- a/spring-cloud-deployer-yarn/src/main/resources/tasklauncher-model.di
+++ b/spring-cloud-deployer-yarn/src/main/resources/tasklauncher-model.di
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"/>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="https://www.omg.org/XMI"/>

--- a/spring-cloud-deployer-yarn/src/main/resources/tasklauncher-model.notation
+++ b/spring-cloud-deployer-yarn/src/main/resources/tasklauncher-model.notation
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<notation:Diagram xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/viewpoints/policy/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_MyLqUBaAEeaeH5SlvwGOyg" type="PapyrusUMLStateMachineDiagram" name="StateMachine Diagram" measurementUnit="Pixel">
+<notation:Diagram xmi:version="2.0" xmlns:xmi="https://www.omg.org/XMI" xmlns:ecore="https://www.eclipse.org/emf/2002/Ecore" xmlns:notation="https://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="https://www.eclipse.org/papyrus/infra/viewpoints/policy/style" xmlns:uml="https://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_MyLqUBaAEeaeH5SlvwGOyg" type="PapyrusUMLStateMachineDiagram" name="StateMachine Diagram" measurementUnit="Pixel">
   <children xmi:type="notation:Shape" xmi:id="_MyLqURaAEeaeH5SlvwGOyg" type="2000">
     <children xmi:type="notation:DecorationNode" xmi:id="_MyLqUhaAEeaeH5SlvwGOyg" type="2001">
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MyLqUxaAEeaeH5SlvwGOyg" width="961" height="23"/>

--- a/spring-cloud-deployer-yarn/src/main/resources/tasklauncher-model.uml
+++ b/spring-cloud-deployer-yarn/src/main/resources/tasklauncher-model.uml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<uml:Model xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_MyH_8BaAEeaeH5SlvwGOyg" name="RootElement">
+<uml:Model xmi:version="20131001" xmlns:xmi="https://www.omg.org/spec/XMI/20131001" xmlns:uml="https://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_MyH_8BaAEeaeH5SlvwGOyg" name="RootElement">
   <packagedElement xmi:type="uml:StateMachine" xmi:id="_MyKcMBaAEeaeH5SlvwGOyg" name="StateMachine">
     <region xmi:type="uml:Region" xmi:id="_MyLDQBaAEeaeH5SlvwGOyg" name="Region1">
       <transition xmi:type="uml:Transition" xmi:id="_FFxDUBkUEeapnMylBysFZA" source="_tbAeMBkTEeapnMylBysFZA" target="_lKKrYBj9EeapnMylBysFZA"/>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.eclipse.org/emf/2002/Ecore (404) with 2 occurrences migrated to:  
  https://www.eclipse.org/emf/2002/Ecore ([https](https://www.eclipse.org/emf/2002/Ecore) result 404).
* [ ] http://www.eclipse.org/gmf/runtime/1.0.2/notation (404) with 2 occurrences migrated to:  
  https://www.eclipse.org/gmf/runtime/1.0.2/notation ([https](https://www.eclipse.org/gmf/runtime/1.0.2/notation) result 404).
* [ ] http://www.eclipse.org/papyrus/infra/viewpoints/policy/style (404) with 2 occurrences migrated to:  
  https://www.eclipse.org/papyrus/infra/viewpoints/policy/style ([https](https://www.eclipse.org/papyrus/infra/viewpoints/policy/style) result 404).
* [ ] http://www.eclipse.org/uml2/5.0.0/UML (404) with 4 occurrences migrated to:  
  https://www.eclipse.org/uml2/5.0.0/UML ([https](https://www.eclipse.org/uml2/5.0.0/UML) result 404).
* [ ] http://www.omg.org/spec/XMI/20131001 (301) with 2 occurrences migrated to:  
  https://www.omg.org/spec/XMI/20131001 ([https](https://www.omg.org/spec/XMI/20131001) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.omg.org/XMI with 4 occurrences migrated to:  
  https://www.omg.org/XMI ([https](https://www.omg.org/XMI) result 301).

# Ignored
These URLs were intentionally ignored.

* http://fakeAddress with 1 occurrences